### PR TITLE
Switched to using AsyncKeyedLock

### DIFF
--- a/SharePoint.Authentication/SharePoint.Authentication.csproj
+++ b/SharePoint.Authentication/SharePoint.Authentication.csproj
@@ -33,8 +33,8 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncKeyedLock, Version=6.1.0.0, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AsyncKeyedLock.6.1.0\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
+    <Reference Include="AsyncKeyedLock, Version=6.1.1.0, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncKeyedLock.6.1.1\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">

--- a/SharePoint.Authentication/SharePoint.Authentication.csproj
+++ b/SharePoint.Authentication/SharePoint.Authentication.csproj
@@ -33,6 +33,9 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AsyncKeyedLock, Version=6.0.4.1, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncKeyedLock.6.0.5\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <HintPath>..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
@@ -92,8 +95,14 @@
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />

--- a/SharePoint.Authentication/SharePoint.Authentication.csproj
+++ b/SharePoint.Authentication/SharePoint.Authentication.csproj
@@ -33,8 +33,8 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncKeyedLock, Version=6.0.4.1, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AsyncKeyedLock.6.0.5\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
+    <Reference Include="AsyncKeyedLock, Version=6.1.0.0, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncKeyedLock.6.1.0\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">

--- a/SharePoint.Authentication/SharePoint.Authentication.csproj
+++ b/SharePoint.Authentication/SharePoint.Authentication.csproj
@@ -33,8 +33,8 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncKeyedLock, Version=6.1.1.0, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AsyncKeyedLock.6.1.1\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
+    <Reference Include="AsyncKeyedLock, Version=6.2.0.0, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncKeyedLock.6.2.0\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">

--- a/SharePoint.Authentication/packages.config
+++ b/SharePoint.Authentication/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncKeyedLock" version="6.1.1" targetFramework="net461" />
+  <package id="AsyncKeyedLock" version="6.2.0" targetFramework="net461" />
   <package id="Microsoft.Identity.Model.Extensions" version="2.0.1459.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net461" />
   <package id="Microsoft.SharePointOnline.CSOM" version="16.1.8715.1200" targetFramework="net461" />

--- a/SharePoint.Authentication/packages.config
+++ b/SharePoint.Authentication/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AsyncKeyedLock" version="6.0.5" targetFramework="net461" />
   <package id="Microsoft.Identity.Model.Extensions" version="2.0.1459.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net461" />
   <package id="Microsoft.SharePointOnline.CSOM" version="16.1.8715.1200" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
 </packages>

--- a/SharePoint.Authentication/packages.config
+++ b/SharePoint.Authentication/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncKeyedLock" version="6.0.5" targetFramework="net461" />
+  <package id="AsyncKeyedLock" version="6.1.0" targetFramework="net461" />
   <package id="Microsoft.Identity.Model.Extensions" version="2.0.1459.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net461" />
   <package id="Microsoft.SharePointOnline.CSOM" version="16.1.8715.1200" targetFramework="net461" />

--- a/SharePoint.Authentication/packages.config
+++ b/SharePoint.Authentication/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncKeyedLock" version="6.1.0" targetFramework="net461" />
+  <package id="AsyncKeyedLock" version="6.1.1" targetFramework="net461" />
   <package id="Microsoft.Identity.Model.Extensions" version="2.0.1459.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net461" />
   <package id="Microsoft.SharePointOnline.CSOM" version="16.1.8715.1200" targetFramework="net461" />


### PR DESCRIPTION
Switched to using AsyncKeyedLock, which provides better performance, reduced allocations and does not retain items in the dictionary.